### PR TITLE
esp-ros-wifi: Support for ROS over WiFi

### DIFF
--- a/src/ros_lib/ESP32Hardware.h
+++ b/src/ros_lib/ESP32Hardware.h
@@ -2,11 +2,16 @@
 #define ROS_ESP32_HARDWARE_H_
 
 extern "C" {
+#include "sdkconfig.h"
 #include "stdio.h"
 #include "esp_err.h"
 #include "esp_timer.h"
 #include <driver/uart.h>
+#include "esp_ros_wifi.h"
 }
+
+#define ROS_SERVER_IP       CONFIG_ROSSERVER_IP
+#define ROS_SERVER_PORT     CONFIG_ROSSERVER_PORT
 
 #define UART_PORT           UART_NUM_0
 #define UART_TX_PIN         GPIO_NUM_1
@@ -25,16 +30,26 @@ class ESP32Hardware
         // Initialization code for ESP32
         void init()
         {
+#ifdef CONFIG_ROSSERIAL_OVER_WIFI
+            esp_ros_wifi_init();
+            ros_tcp_connect(ROS_SERVER_IP, ROS_SERVER_PORT);
+#else
             uart_driver_install(UART_PORT, 1024, 1024, 0, NULL, 0);
 
+            //Changing the baudrate will change the baudrate of serial monitor as well
             //uart_set_baudrate(UART_PORT, 57600);
+#endif
         }
 
         // read a byte from the serial port. -1 = failure
         int read()
         {
             int read_len;
+#ifdef CONFIG_ROSSERIAL_OVER_WIFI
+            read_len = ros_tcp_read(rx_buf, 1);
+#else
             read_len = uart_read_bytes(UART_PORT, (uint8_t *)rx_buf, 1, 0);
+#endif
             if (read_len == 1) {
                 return rx_buf[0];
             } else {
@@ -45,7 +60,11 @@ class ESP32Hardware
         // write data to the connection to ROS
         void write(uint8_t* data, int length)
         {
+#ifdef CONFIG_ROSSERIAL_OVER_WIFI
+            ros_tcp_send(data, length);
+#else
             uart_write_bytes(UART_PORT, (char*)data, (size_t)length);
+#endif
         }
 
         // returns milliseconds since start of program

--- a/src/ros_lib/Kconfig
+++ b/src/ros_lib/Kconfig
@@ -1,0 +1,39 @@
+menu "rosserial"
+
+config ROSSERIAL_OVER_WIFI
+    bool "rosserial over WiFi using TCP"
+    default n
+    help
+        Use rosserial over WiFi using TCP
+
+config ROSSERVER_AP
+    string "WiFi SSID"
+    default "myssid"
+    depends on ROSSERIAL_OVER_WIFI
+    help
+        SSID (Access point name) of WiFi to connect
+
+config ROSSERVER_PASS
+    string "WiFi Password"
+    default "mypass"
+    depends on ROSSERIAL_OVER_WIFI
+    help
+        Password of the WiFi
+
+config ROSSERVER_IP
+    string "IP address of ROS server (roscore)"
+    default "192.168.0.1"
+    depends on ROSSERIAL_OVER_WIFI
+    help
+        IP address of machine which is running rosserial server
+
+config ROSSERVER_PORT
+    int "Port number of ROS server"
+    default 11411
+    depends on ROSSERIAL_OVER_WIFI
+    help
+        Port number of rosserial server
+
+        Port number is printed on terminal running rosserial_python
+
+endmenu

--- a/src/ros_lib/esp_ros_wifi.c
+++ b/src/ros_lib/esp_ros_wifi.c
@@ -1,0 +1,138 @@
+/*
+ * WiFi initialization for setting up ROS communication over TCP sockets
+*/
+
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "esp_event_loop.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "sdkconfig.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include <lwip/netdb.h>
+
+#define MAXIMUM_RETRY  5
+
+#define ROS_SERVER_AP        CONFIG_ROSSERVER_AP
+#define ROS_SERVER_PASS      CONFIG_ROSSERVER_PASS
+
+static EventGroupHandle_t wifi_event_group;
+
+const int IPV4_GOTIP_BIT = BIT0;
+
+static const char *TAG = "esp-ros-wifi";
+
+static int s_retry_num = 0;
+
+static char addr_str[128];
+static int addr_family;
+static int ip_protocol;
+static int sock;
+
+static esp_err_t event_handler(void *ctx, system_event_t *event)
+{
+    switch(event->event_id) {
+    case SYSTEM_EVENT_STA_START:
+        esp_wifi_connect();
+        break;
+    case SYSTEM_EVENT_STA_GOT_IP:
+        ESP_LOGI(TAG, "got ip:%s",
+                 ip4addr_ntoa(&event->event_info.got_ip.ip_info.ip));
+        s_retry_num = 0;
+        xEventGroupSetBits(wifi_event_group, IPV4_GOTIP_BIT);
+        break;
+    case SYSTEM_EVENT_STA_DISCONNECTED:
+        {
+            if (s_retry_num < MAXIMUM_RETRY) {
+                esp_wifi_connect();
+                xEventGroupClearBits(wifi_event_group, IPV4_GOTIP_BIT);
+                s_retry_num++;
+                ESP_LOGI(TAG,"Retrying connection to AP");
+            }
+            ESP_LOGE(TAG,"Failed to connect to AP");
+            break;
+        }
+    default:
+        break;
+    }
+    return ESP_OK;
+}
+
+void esp_ros_wifi_init()
+{
+    nvs_flash_init();
+
+    wifi_event_group = xEventGroupCreate();
+
+    tcpip_adapter_init();
+    ESP_ERROR_CHECK(esp_event_loop_init(event_handler, NULL) );
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = ROS_SERVER_AP,
+            .password = ROS_SERVER_PASS,
+        },
+    };
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config) );
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    ESP_LOGI(TAG, "Waiting for AP connection...");
+    xEventGroupWaitBits(wifi_event_group, IPV4_GOTIP_BIT, false, true, portMAX_DELAY);
+    ESP_LOGI(TAG, "Connected to AP");
+}
+
+void ros_tcp_connect(const char* host_ip, int port_num)
+{
+    struct sockaddr_in destAddr;
+    destAddr.sin_addr.s_addr = inet_addr(host_ip);
+    destAddr.sin_family = AF_INET;
+    destAddr.sin_port = htons(port_num);
+    addr_family = AF_INET;
+    ip_protocol = IPPROTO_IP;
+    inet_ntoa_r(destAddr.sin_addr, addr_str, sizeof(addr_str) - 1);
+
+    sock = socket(addr_family, SOCK_STREAM, ip_protocol);
+    if (sock < 0) {
+        ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
+    }
+
+    /* Set sock to non-blocking mode (ASYNC)
+     * "Lost sync with device, restarting.." error occurs if socket is blocking
+     */
+    fcntl(sock, F_SETFL, O_NONBLOCK);
+
+    int err = connect(sock, (struct sockaddr *)&destAddr, sizeof(destAddr));
+    if (err != 0 && errno != 119) {
+        ESP_LOGE(TAG, "Socket unable to connect: errno %d", errno);
+    }
+    ESP_LOGI(TAG, "Successfully connected");
+}
+
+void ros_tcp_send(uint8_t* data, int length)
+{
+    int err = send(sock, data, length, 0);
+    if (err < 0) {
+        ESP_LOGE(TAG, "Error occured during sending: errno %d", errno);
+    }
+}
+
+int ros_tcp_read(uint8_t* buf, int length)
+{
+    int len = recv(sock, buf, length, 0);
+    if (len < 0 && errno != 11) {
+        ESP_LOGE(TAG, "Error receiving data: errno %d", errno);
+        return -1;
+    }
+    return len;
+}

--- a/src/ros_lib/esp_ros_wifi.h
+++ b/src/ros_lib/esp_ros_wifi.h
@@ -1,0 +1,9 @@
+#pragma once
+
+void esp_ros_wifi_init();
+
+void ros_tcp_connect(const char* host_ip, int port_num);
+
+void ros_tcp_send(uint8_t* data, int length);
+
+int ros_tcp_read(uint8_t* buf, int length);

--- a/src/rosserial_esp32/make_libraries.py
+++ b/src/rosserial_esp32/make_libraries.py
@@ -75,6 +75,7 @@ if (len(sys.argv) < 2):
 
 # get output path
 path = sys.argv[1]
+
 if path[-1] == "/":
     path = path[0:-1]
 print "\nExporting to %s" % path
@@ -91,8 +92,12 @@ if not os.path.exists(path+"/rosserial_esp32/"):
 rosserial_esp32_dir = rospack.get_path(THIS_PACKAGE)
 files = os.listdir(rosserial_esp32_dir+"/src/ros_lib")
 for f in files:
-  if os.path.isfile(rosserial_esp32_dir+"/src/ros_lib/"+f):
-    shutil.copy(rosserial_esp32_dir+"/src/ros_lib/"+f, path+"/rosserial_esp32/include/")
+    if os.path.isfile(rosserial_esp32_dir+"/src/ros_lib/"+f):
+        if f.endswith(".h"):
+            shutil.copy(rosserial_esp32_dir+"/src/ros_lib/"+f, path+"/rosserial_esp32/include/")
+        else:
+            shutil.copy(rosserial_esp32_dir+"/src/ros_lib/"+f, path+"/rosserial_esp32/")
+
 rosserial_client_copy_files(rospack, path+"/rosserial_esp32/include/")
 
 # generate messages


### PR DESCRIPTION
Allows rosserial to communicate over WiFi using TCP sockets

To use ROS over WiFi, enable `CONFIG_ROSSERIAL_OVER_WIFI` from `menuconfig`

`Component config` -> `rosserial` -> `rosserial over WiFi using TCP`

While running rosserial_python use:
`rosrun rosserial_python serial_node.py tcp`

Signed-off-by: Sachin Parekh <sachin.parekh@espressif.com>